### PR TITLE
Changed 'lastword' to 'firstword' due to the order of MAKEFILE_LIST with includes braking "make help"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,4 +120,4 @@ print-make-variables:
 help:
 	@echo "Build $(PROGRAM_NAME) version $(BUILD_VERSION)-$(BUILD_ITERATION)".
 	@echo "All targets:"
-	@$(MAKE) -pRrq -f $(lastword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs
+	@$(MAKE) -pRrq -f $(firstword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | xargs


### PR DESCRIPTION
`make help` was not finding targets because the `MAKEFILE_LIST` had the included make files AFTER the standard `Makefile` -- so this means it would use `Makefile.osdetect` or `Makefile.darwin` (on macOS) and would not find any targets in those.

This was because `$(lastword $(MAKEFILE_LIST))` was used and it should have been `$(firstword $(MAKEFILE_LIST))`
